### PR TITLE
Add publish config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ pnpm-debug.log*
 /src-cordova/www
 /public/cordova.js
 src-cordova/com.scopevisio.erp.server_cordova_build_templates_apk_sign.jks
+
+docs/eudgc.js

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@kenai/eudgc",
+  "name": "@Spookfish-ai/eudgc",
   "version": "1.0.6",
   "description": "EuDGC (European Digital Green Certificate) handling in Javascript and Typescript",
   "main": "./dist/index.js",
@@ -47,6 +47,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Scopevisio/eudgc"
+    "url": "https://github.com/Spookfish-ai/eudgc.git"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "dev": "tsup src/index.ts --format cjs --watch --dts",
-    "build": "tsup src/index.ts --format cjs --dts && cp dist/eudgc.js docs",
-    "prepublishOnly": "tsup src/index.ts --format cjs --dts && cp dist/eudgc.js docs",
+    "build": "tsup src/index.ts --format cjs --dts && cp dist/index.js docs/eudgc.js",
+    "prepublishOnly": "tsup src/index.ts --format cjs --dts && cp dist/index.js docs/eudgc.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [


### PR DESCRIPTION
The way we are consuming this package is weird, we install it with the following:
```
 "@kenai/eudgc": "github:Spookfish-ai/eudgc",
```

This requires an unconventional npmrc config, and the namespace `@kenai` is already used by bit.

This update allows us to publish it to github and then use a conventional install:
```
"@Spookfish-ai/eudgc": "1.0.6",
```